### PR TITLE
Handle overflow better

### DIFF
--- a/src/slice_vec.rs
+++ b/src/slice_vec.rs
@@ -384,9 +384,11 @@ mod tests {
         let mut data = [0u8; 31];
         let mut sv: SliceVec<usize> = SliceVec::from_bytes(&mut data[..]);
         assert!(sv.is_empty());
-        assert!(sv.capacity() > 0);
-        for i in 0..sv.capacity() {
-            assert_eq!(Ok(()), sv.try_push(i));
+        // capacity might be 0 if miri messes with the align-ability of pointers
+        if sv.capacity() > 0 {
+            for i in 0..sv.capacity() {
+                assert_eq!(Ok(()), sv.try_push(i));
+            }
         }
         assert!(sv.is_full());
     }


### PR DESCRIPTION
More complete handling of the fact that the implementation of `align_offset` is allowed to indicate that aligning a pointer is impossible by returning core::usize::MAX.

See also: https://doc.rust-lang.org/std/primitive.pointer.html#method.align_offset

 Discovered thanks to [miri](https://github.com/rust-lang/miri)