### PR TITLE
Expand comparability testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ readme = "README.md"
 description = "`FixedSliceVec` is a dynamic length Vec with runtime-determined maximum capacity backed by a slice."
 keywords = ["vec", "vector", "no_std", "slice", "no-std"]
 categories = ["embedded", "data-structures", "no-std"]
+
+[dev-dependencies]
+arrayvec = "0.5"
+proptest = "0.9.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "fixed-slice-vec"
-version = "0.4.0"
-authors = ["Zachary Pierce <zack@auxon.io>"]
+version = "0.5.0"
+authors = [
+    "Zachary Pierce <zack@auxon.io>",
+    "Jon Lamb <jon@auxon.io>",
+    "Russell Mull <russell@auxon.io>",
+    "dan pittman <dan@auxon.io>",
+]
 edition = "2018"
 license = "Apache-2.0"
 homepage = "https://github.com/auxoncorp/fixed-slice-vec"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To add `fixed-slice-vec` to your Rust project, add a dependency to it
 in your Cargo.toml file.
 
 ```toml
-fixed-slice-vec = "0.3"
+fixed-slice-vec = "0.5"
 ```
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ nightly-only.
 This is the closest in its target use case to `FixedSliceVec`. We
 only discovered it existed after developing `FixedSliceVec`, so there's some
 evidence of convergent design or needs. It appears largely
-unmaintained over the last few years, and does not make use of the
+unmaintained over the last few years, does not make use of the
 [MaybeUninit](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html)
-pattern for handling uninitialized data in Rust. Presently it supports a few
-more of the convenience methods available in standard `Vec` than
-`FixedSliceVec`. It does not support creating an instance from raw bytes.
+pattern for handling uninitialized data in Rust, and does not drop items
+correctly in some cases. It does not support creating an instance from raw bytes
+and requires `Default` elements for some operations.
 
 
 ### License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,11 +67,11 @@
 //! This is the closest in its target use case to `FixedSliceVec`. We
 //! only discovered it existed after developing `FixedSliceVec`, so there's some
 //! evidence of convergent design or needs. It appears largely
-//! unmaintained over the last few years, and does not make use of the
+//! unmaintained over the last few years, does not make use of the
 //! [MaybeUninit](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html)
-//! pattern for handling uninitialized data in Rust. Presently it supports a few
-//! more of the convenience methods available in standard `Vec` than
-//! `FixedSliceVec`. It does not support creating an instance from raw bytes.
+//! pattern for handling uninitialized data in Rust, and does not drop items
+//! correctly in some cases. It does not support creating an instance from raw bytes
+//! and requires `Default` elements for some operations.
 //!
 //!
 //! ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@
 #![no_std]
 #![deny(warnings)]
 #![deny(missing_docs)]
+#![deny(clippy::all)]
 
 pub mod single;
 pub mod vec;

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,4 +1,4 @@
-//! SliceVec is a structure for defining variably populated vectors backed
+//! FixedSliceVec is a structure for defining variably populated vectors backed
 //! by a slice of storage capacity.
 use core::borrow::{Borrow, BorrowMut};
 use core::convert::From;
@@ -25,21 +25,21 @@ impl<'a, T: Sized> Drop for FixedSliceVec<'a, T> {
 }
 
 impl<'a, T: Sized> FixedSliceVec<'a, T> {
-    /// Create a SliceVec backed by a slice of possibly-uninitialized data.
+    /// Create a FixedSliceVec backed by a slice of possibly-uninitialized data.
     /// The backing storage slice is used as capacity for Vec-like operations,
     ///
-    /// The initial length of the SliceVec is 0.
+    /// The initial length of the FixedSliceVec is 0.
     #[inline]
     pub fn new(storage: &'a mut [MaybeUninit<T>]) -> Self {
         FixedSliceVec { storage, len: 0 }
     }
 
-    /// Create a well-aligned SliceVec backed by a slice of the provided bytes.
+    /// Create a well-aligned FixedSliceVec backed by a slice of the provided bytes.
     /// The slice is as large as possible given the item type and alignment of
     /// the provided bytes.
     ///
     /// If you are interested in recapturing the prefix and suffix bytes on
-    /// either side of the carved-out SliceVec buffer, consider using `align_from_bytes` instead:
+    /// either side of the carved-out FixedSliceVec buffer, consider using `align_from_bytes` instead:
     ///
     /// ```
     /// # let mut bytes = [3u8, 1, 4, 1, 5, 9];
@@ -48,19 +48,19 @@ impl<'a, T: Sized> FixedSliceVec<'a, T> {
     /// ```
     ///
     /// The bytes are treated as if they might be uninitialized, so even if `T` is `u8`,
-    /// the length of the returned `SliceVec` will be zero.
+    /// the length of the returned `FixedSliceVec` will be zero.
     #[inline]
     pub fn from_bytes(bytes: &'a mut [u8]) -> FixedSliceVec<'a, T> {
         let (_prefix, fixed_slice_vec, _suffix) = FixedSliceVec::align_from_bytes(bytes);
         fixed_slice_vec
     }
 
-    /// Create a well-aligned SliceVec backed by a slice of the provided
+    /// Create a well-aligned FixedSliceVec backed by a slice of the provided
     /// uninitialized bytes. The typed slice is as large as possible given its
     /// item type and the alignment of the provided bytes.
     ///
     /// If you are interested in recapturing the prefix and suffix bytes on
-    /// either side of the carved-out SliceVec buffer, consider using `align_from_uninit_bytes`:
+    /// either side of the carved-out FixedSliceVec buffer, consider using `align_from_uninit_bytes`:
     ///
     #[inline]
     pub fn from_uninit_bytes(bytes: &'a mut [MaybeUninit<u8>]) -> FixedSliceVec<'a, T> {
@@ -68,10 +68,10 @@ impl<'a, T: Sized> FixedSliceVec<'a, T> {
         fixed_slice_vec
     }
 
-    /// Create a well-aligned SliceVec backed by a slice of the provided bytes.
+    /// Create a well-aligned FixedSliceVec backed by a slice of the provided bytes.
     /// The slice is as large as possible given the item type and alignment of
     /// the provided bytes. Returns the unused prefix and suffix bytes on
-    /// either side of the carved-out SliceVec.
+    /// either side of the carved-out FixedSliceVec.
     ///
     /// ```
     /// let mut bytes = [3u8, 1, 4, 1, 5, 9];
@@ -80,7 +80,7 @@ impl<'a, T: Sized> FixedSliceVec<'a, T> {
     /// ```
     ///
     /// The bytes are treated as if they might be uninitialized, so even if `T` is `u8`,
-    /// the length of the returned `SliceVec` will be zero.
+    /// the length of the returned `FixedSliceVec` will be zero.
     #[inline]
     pub fn align_from_bytes(
         bytes: &'a mut [u8],
@@ -89,10 +89,10 @@ impl<'a, T: Sized> FixedSliceVec<'a, T> {
         (prefix, FixedSliceVec { storage, len: 0 }, suffix)
     }
 
-    /// Create a well-aligned SliceVec backed by a slice of the provided bytes.
+    /// Create a well-aligned FixedSliceVec backed by a slice of the provided bytes.
     /// The slice is as large as possible given the item type and alignment of
     /// the provided bytes. Returns the unused prefix and suffix bytes on
-    /// either side of the carved-out SliceVec.
+    /// either side of the carved-out FixedSliceVec.
     ///
     /// ```
     /// # use core::mem::MaybeUninit;
@@ -102,7 +102,7 @@ impl<'a, T: Sized> FixedSliceVec<'a, T> {
     /// let vec: fixed_slice_vec::FixedSliceVec<u16> = vec;
     /// ```
     ///
-    /// The length of the returned `SliceVec` will be zero.
+    /// The length of the returned `FixedSliceVec` will be zero.
     #[inline]
     pub fn align_from_uninit_bytes(
         bytes: &'a mut [MaybeUninit<u8>],
@@ -115,14 +115,14 @@ impl<'a, T: Sized> FixedSliceVec<'a, T> {
         (prefix, FixedSliceVec { storage, len: 0 }, suffix)
     }
 
-    /// The length of the SliceVec. The number of initialized
+    /// The length of the FixedSliceVec. The number of initialized
     /// values that have been added to it.
     #[inline]
     pub fn len(&self) -> usize {
         self.len
     }
 
-    /// The maximum amount of items that can live in this SliceVec
+    /// The maximum amount of items that can live in this FixedSliceVec
     #[inline]
     pub fn capacity(&self) -> usize {
         self.storage.len()
@@ -134,26 +134,26 @@ impl<'a, T: Sized> FixedSliceVec<'a, T> {
         self.len == 0
     }
 
-    /// Returns true if the SliceVec is full to capacity.
+    /// Returns true if the FixedSliceVec is full to capacity.
     #[inline]
     pub fn is_full(&self) -> bool {
         self.len == self.capacity()
     }
 
-    /// Attempt to add a value to the SliceVec.
+    /// Attempt to add a value to the FixedSliceVec.
     ///
     /// Returns an error if there is not enough capacity to hold another item.
     #[inline]
-    pub fn try_push(&mut self, value: T) -> Result<(), TryPushError<T>> {
+    pub fn try_push(&mut self, value: T) -> Result<(), StorageError<T>> {
         if self.is_full() {
-            return Err(TryPushError(value));
+            return Err(StorageError(value));
         }
         self.storage[self.len] = MaybeUninit::new(value);
         self.len += 1;
         Ok(())
     }
 
-    /// Attempt to add a value to the SliceVec.
+    /// Attempt to add a value to the FixedSliceVec.
     ///
     /// # Panics
     ///
@@ -163,7 +163,7 @@ impl<'a, T: Sized> FixedSliceVec<'a, T> {
         self.try_push(value).unwrap();
     }
 
-    /// Remove the last item from the SliceVec.
+    /// Remove the last item from the FixedSliceVec.
     #[inline]
     pub fn pop(&mut self) -> Option<T> {
         if self.len == 0 {
@@ -178,7 +178,7 @@ impl<'a, T: Sized> FixedSliceVec<'a, T> {
         v
     }
 
-    /// Removes the SliceVec's tracking of all items in it while retaining the
+    /// Removes the FixedSliceVec's tracking of all items in it while retaining the
     /// same capacity.
     #[inline]
     pub fn clear(&mut self) {
@@ -189,28 +189,29 @@ impl<'a, T: Sized> FixedSliceVec<'a, T> {
     }
 
     /// Obtain an immutable slice view on the initialized portion of the
-    /// SliceVec.
+    /// FixedSliceVec.
     #[inline]
     pub fn as_slice(&self) -> &[T] {
         self
     }
 
     /// Obtain a mutable slice view on the initialized portion of the
-    /// SliceVec.
+    /// FixedSliceVec.
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         self
     }
 }
 
-/// Error that occurs when a call to `try_push` fails due
-/// to insufficient capacity in the SliceVec.
+/// Error that occurs when a call that attempts to increase
+/// the number of items in the FixedSliceVec fails
+/// due to insufficient storage capacity.
 #[derive(Clone, PartialEq, PartialOrd, Eq, Ord)]
-pub struct TryPushError<T>(pub T);
+pub struct StorageError<T>(pub T);
 
-impl<T> core::fmt::Debug for TryPushError<T> {
+impl<T> core::fmt::Debug for StorageError<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
-        f.write_str("Push failed because SliceVec was full")
+        f.write_str("Push failed because FixedSliceVec was full")
     }
 }
 

--- a/tests/comparability_tests.rs
+++ b/tests/comparability_tests.rs
@@ -1,3 +1,4 @@
+use arrayvec::ArrayVec;
 use fixed_slice_vec::*;
 use std::mem::MaybeUninit;
 use std::sync::{
@@ -18,16 +19,113 @@ impl Drop for DropCountingItem {
 
 trait VecLike {
     type Item: Sized;
-    fn push(&mut self, item: Self::Item);
+    fn try_push(&mut self, item: Self::Item) -> Result<(), ()>;
+    fn push(&mut self, item: Self::Item) {
+        self.try_push(item).unwrap()
+    }
+
     fn pop(&mut self) -> Option<Self::Item>;
     fn clear(&mut self);
     fn capacity(&self) -> usize;
+    fn as_slice(&self) -> &[Self::Item];
     fn as_mut_slice(&mut self) -> &mut [Self::Item];
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    fn len(&self) -> usize {
+        self.as_slice().len()
+    }
 }
 
-impl VecLike for Vec<DropCountingItem> {
-    type Item = DropCountingItem;
+impl<T> VecLike for Vec<T> {
+    type Item = T;
 
+    fn try_push(&mut self, item: Self::Item) -> Result<(), ()> {
+        Vec::push(self, item);
+        Ok(())
+    }
+
+    fn push(&mut self, item: Self::Item) {
+        Vec::push(self, item)
+    }
+
+    fn pop(&mut self) -> Option<Self::Item> {
+        Vec::pop(self)
+    }
+
+    fn clear(&mut self) {
+        Vec::clear(self)
+    }
+
+    fn capacity(&self) -> usize {
+        Vec::capacity(self)
+    }
+
+    fn as_slice(&self) -> &[Self::Item] {
+        self
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [Self::Item] {
+        self
+    }
+
+    fn is_empty(&self) -> bool {
+        Vec::is_empty(self)
+    }
+
+    fn len(&self) -> usize {
+        Vec::len(self)
+    }
+}
+
+impl<'a, T> VecLike for &'a mut Vec<T> {
+    type Item = T;
+
+    fn try_push(&mut self, item: Self::Item) -> Result<(), ()> {
+        Vec::push(self, item);
+        Ok(())
+    }
+
+    fn push(&mut self, item: Self::Item) {
+        Vec::push(self, item)
+    }
+
+    fn pop(&mut self) -> Option<Self::Item> {
+        Vec::pop(self)
+    }
+
+    fn clear(&mut self) {
+        Vec::clear(self)
+    }
+
+    fn capacity(&self) -> usize {
+        Vec::capacity(self)
+    }
+
+    fn as_slice(&self) -> &[Self::Item] {
+        self
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [Self::Item] {
+        self
+    }
+
+    fn is_empty(&self) -> bool {
+        Vec::is_empty(self)
+    }
+
+    fn len(&self) -> usize {
+        Vec::len(self)
+    }
+}
+
+impl<'a, T> VecLike for FixedSliceVec<'a, T> {
+    type Item = T;
+
+    fn try_push(&mut self, item: Self::Item) -> Result<(), ()> {
+        self.try_push(item).map_err(|_| ())
+    }
     fn push(&mut self, item: Self::Item) {
         self.push(item);
     }
@@ -44,32 +142,52 @@ impl VecLike for Vec<DropCountingItem> {
         self.capacity()
     }
 
+    fn as_slice(&self) -> &[Self::Item] {
+        self
+    }
+
     fn as_mut_slice(&mut self) -> &mut [Self::Item] {
         self
     }
 }
 
-impl<'a> VecLike for FixedSliceVec<'a, DropCountingItem> {
-    type Item = DropCountingItem;
+impl<'a, T> VecLike for ArrayVec<[T; 32]> {
+    type Item = T;
+
+    fn try_push(&mut self, item: Self::Item) -> Result<(), ()> {
+        ArrayVec::try_push(self, item).map_err(|_| ())
+    }
 
     fn push(&mut self, item: Self::Item) {
-        self.push(item);
+        ArrayVec::push(self, item)
     }
 
     fn pop(&mut self) -> Option<Self::Item> {
-        self.pop()
+        ArrayVec::pop(self)
     }
 
     fn clear(&mut self) {
-        self.clear();
+        ArrayVec::clear(self)
     }
 
     fn capacity(&self) -> usize {
-        self.capacity()
+        ArrayVec::capacity(self)
+    }
+
+    fn as_slice(&self) -> &[Self::Item] {
+        ArrayVec::as_slice(self)
     }
 
     fn as_mut_slice(&mut self) -> &mut [Self::Item] {
-        self
+        ArrayVec::as_mut_slice(self)
+    }
+
+    fn is_empty(&self) -> bool {
+        ArrayVec::len(self) == 0
+    }
+
+    fn len(&self) -> usize {
+        ArrayVec::len(self)
     }
 }
 
@@ -156,4 +274,117 @@ fn drops_items_replaced_via_mut_slice() {
         unsafe { MaybeUninit::uninit().assume_init() };
     let sv: FixedSliceVec<_> = FixedSliceVec::new(&mut backing[..]);
     assert_vec_like_drops_items_replaced_via_mut_slice(sv);
+}
+
+pub mod vec_like_operations {
+    use super::*;
+    use proptest::prelude::*;
+    #[derive(Debug, Clone)]
+    pub enum VecLikeOp<T> {
+        Push(T),
+        Pop,
+        Clear,
+    }
+
+    fn arbitrary_vec_like_op() -> impl Strategy<Value = VecLikeOp<u16>> {
+        // Weighted to avoid clearing so often that we only rarely encounter
+        // border conditions
+        prop_oneof! [
+            20 => any::<u16>().prop_map(|v| VecLikeOp::Push(v)),
+            15 => Just(VecLikeOp::Pop),
+            1 => Just(VecLikeOp::Clear),
+        ]
+    }
+
+    fn prop_assert_equivalent<'a, T>(
+        other_vec: &mut dyn VecLike<Item = T>,
+        fixed_slice_vec: &mut FixedSliceVec<'a, T>,
+    ) -> Result<(), TestCaseError>
+    where
+        T: std::fmt::Debug,
+        T: PartialEq,
+    {
+        prop_assert_eq!(
+            other_vec.as_slice(),
+            fixed_slice_vec.as_slice(),
+            "Slice contents"
+        );
+        prop_assert_eq!(
+            other_vec.as_mut_slice(),
+            fixed_slice_vec.as_mut_slice(),
+            "Mutable slice contents"
+        );
+        prop_assert_eq!(other_vec.len(), fixed_slice_vec.len(), "Lengths");
+        prop_assert_eq!(
+            other_vec.is_empty(),
+            fixed_slice_vec.is_empty(),
+            "Empty statuses"
+        );
+        Ok(())
+    }
+
+    fn assert_alike_operations(
+        other_vec: &mut dyn VecLike<Item = u16>,
+        operations: Vec<VecLikeOp<u16>>,
+        mut storage_bytes: Vec<u8>,
+    ) -> Result<(), TestCaseError> {
+        let mut fs_vec: FixedSliceVec<u16> = FixedSliceVec::from_bytes(&mut storage_bytes);
+        for op in operations {
+            match op {
+                VecLikeOp::Push(v) => {
+                    let fs_result = fs_vec.try_push(v);
+                    if let Err(e) = fs_result {
+                        prop_assert!(fs_vec.is_full(), "FixedSliceVec should only reject pushes when full. Failed pushing {:?}", e);
+                    } else {
+                        if let Err(e) = other_vec.try_push(v) {
+                            prop_assert_eq!(other_vec.capacity(), other_vec.len(), "Other VecLike implementations should only reject when full. Failed pushing {:?}", e);
+                            // Roll back the value just added so we don't diverge simply because
+                            // of different capacities.
+                            assert_eq!(
+                                Some(v),
+                                fs_vec.pop(),
+                                "Ought to have popped back what we just pushed"
+                            );
+                        }
+                    }
+                }
+                VecLikeOp::Clear => {
+                    fs_vec.clear();
+                    other_vec.clear();
+                }
+                VecLikeOp::Pop => {
+                    let fs_result = fs_vec.pop();
+                    let std_result = other_vec.pop();
+                    prop_assert_eq!(
+                        std_result,
+                        fs_result,
+                        "Returned values from `pop` should be the same"
+                    );
+                }
+            }
+            prop_assert_equivalent(other_vec, &mut fs_vec)?;
+        }
+        Ok(())
+    }
+
+    proptest! {
+        #[test]
+        #[cfg_attr(miri, ignore)]
+        fn compare_vec_like_operations_against_std(
+            operations in proptest::collection::vec(arbitrary_vec_like_op(), 1..1000),
+            storage_bytes in proptest::collection::vec(Just(0u8), 0..1024)
+        ) {
+            let mut std_vec = Vec::new();
+            assert_alike_operations(&mut std_vec, operations, storage_bytes)?;
+        }
+        #[test]
+        #[cfg_attr(miri, ignore)]
+        fn compare_vec_like_operations_against_array_vec(
+            operations in proptest::collection::vec(arbitrary_vec_like_op(), 1..1000),
+            storage_bytes in proptest::collection::vec(Just(0u8), 0..1024)
+        ) {
+            let mut av_vec: ArrayVec<[u16; 32]> = ArrayVec::new();
+            assert_alike_operations(&mut av_vec, operations, storage_bytes)?;
+        }
+    }
 }

--- a/tests/std_required_tests.rs
+++ b/tests/std_required_tests.rs
@@ -1,0 +1,44 @@
+//! Tests that require access to the standard library,
+//! e.g. for catching panics
+
+use fixed_slice_vec::FixedSliceVec;
+use std::panic::AssertUnwindSafe;
+
+#[test]
+fn manual_remove() {
+    let mut storage = [0u8, 2, 4, 8];
+    let mut fsv = FixedSliceVec::from(&mut storage[..]);
+    assert_eq!(2, fsv.remove(1));
+    assert_eq!(&[0u8, 4, 8], fsv.as_slice());
+
+    let unwind = std::panic::catch_unwind(AssertUnwindSafe(|| fsv.remove(100)));
+    assert!(unwind.is_err());
+}
+
+#[test]
+fn manual_push() {
+    let mut storage = [0u8; 16];
+    let mut fsv: FixedSliceVec<u32> = FixedSliceVec::from_bytes(&mut storage[..]);
+    fsv.push(314);
+    assert_eq!(&[314u32], fsv.as_slice());
+
+    let unwind = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        for i in 0..16 {
+            fsv.push(i)
+        }
+    }));
+    assert!(unwind.is_err());
+}
+
+#[test]
+fn manual_try_swap_remove() {
+    let mut storage = [0u8, 2, 4, 8];
+    let mut fsv = FixedSliceVec::from(&mut storage[..]);
+    let unwind = std::panic::catch_unwind(AssertUnwindSafe(|| fsv.remove(100)));
+    assert!(unwind.is_err());
+    let unwind = std::panic::catch_unwind(AssertUnwindSafe(|| fsv.remove(4)));
+    assert!(unwind.is_err());
+    assert_eq!(&[0u8, 2, 4, 8], fsv.as_slice());
+    assert_eq!(Ok(2), fsv.try_swap_remove(1));
+    assert_eq!(&[0u8, 8, 4], fsv.as_slice());
+}


### PR DESCRIPTION
Widens the API to cover more of `Vec` (including non-panicking modes of failure) and use prop-testing to ensure comparability.