### PR TITLE
Remove direct slice construction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed-slice-vec"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Zachary Pierce <zack@auxon.io>",
     "Jon Lamb <jon@auxon.io>",

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To add `fixed-slice-vec` to your Rust project, add a dependency to it
 in your Cargo.toml file.
 
 ```toml
-fixed-slice-vec = "0.5"
+fixed-slice-vec = "0.6"
 ```
 
 ### Usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! in your Cargo.toml file.
 //!
 //! ```toml
-//! fixed-slice-vec = "0.3"
+//! fixed-slice-vec = "0.6"
 //! ```
 //!
 //! ## Usage

--- a/tests/std_required_tests.rs
+++ b/tests/std_required_tests.rs
@@ -6,8 +6,11 @@ use std::panic::AssertUnwindSafe;
 
 #[test]
 fn manual_remove() {
-    let mut storage = [0u8, 2, 4, 8];
-    let mut fsv = FixedSliceVec::from(&mut storage[..]);
+    let expected = [0u8, 2, 4, 8];
+    let mut storage = [0u8; 4];
+    let mut fsv = FixedSliceVec::from_bytes(&mut storage[..]);
+    assert!(fsv.try_extend(expected.iter().copied()).is_ok());
+
     assert_eq!(2, fsv.remove(1));
     assert_eq!(&[0u8, 4, 8], fsv.as_slice());
 
@@ -32,8 +35,11 @@ fn manual_push() {
 
 #[test]
 fn manual_try_swap_remove() {
-    let mut storage = [0u8, 2, 4, 8];
-    let mut fsv = FixedSliceVec::from(&mut storage[..]);
+    let expected = [0u8, 2, 4, 8];
+    let mut storage = [0u8; 4];
+    let mut fsv = FixedSliceVec::from_bytes(&mut storage[..]);
+    assert!(fsv.try_extend(expected.iter().copied()).is_ok());
+
     let unwind = std::panic::catch_unwind(AssertUnwindSafe(|| fsv.remove(100)));
     assert!(unwind.is_err());
     let unwind = std::panic::catch_unwind(AssertUnwindSafe(|| fsv.remove(4)));


### PR DESCRIPTION
This sidesteps the possibility of a double-free problem for non-Copy types.

To replace the loss of this convenience, some population-from-iterator options have been added: `impl core::iter::Extend` and `FixedSliceVec::try_extend`.