### PR TITLE
Expand CI testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,3 +53,24 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: miri, rust-src
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: miri
+          args: setup
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: miri
+          args: test --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ Cargo.lock
 
 # tarpaulin reports
 tarpaulin-report.*
+
+# fuzz related
+fuzz/target
+fuzz/artifacts
+fuzz/corpus

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Cargo.lock
 
 # IDE files
 .idea
+
+# tarpaulin reports
+tarpaulin-report.*

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+
+[package]
+name = "fixed-slice-vec-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = { version = "0.3", features = ["arbitrary-derive"] }
+
+[dependencies.fixed-slice-vec]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "vec_like_ops"
+path = "fuzz_targets/vec_like_ops.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/vec_like_ops.rs
+++ b/fuzz/fuzz_targets/vec_like_ops.rs
@@ -1,0 +1,51 @@
+#![no_main]
+extern crate fixed_slice_vec;
+extern crate libfuzzer_sys;
+use fixed_slice_vec::FixedSliceVec;
+use libfuzzer_sys::{arbitrary, fuzz_target};
+
+#[derive(Debug, Clone, arbitrary::Arbitrary)]
+pub struct Harness {
+    storage: Vec<u8>,
+    ops: Vec<VecLikeOp<String>>,
+}
+#[derive(Debug, Clone, arbitrary::Arbitrary)]
+pub enum VecLikeOp<T> {
+    Push(T),
+    Pop,
+    Clear,
+    Truncate(usize),
+    Remove(usize),
+    SwapRemove(usize),
+    Extend(Vec<T>),
+}
+
+fuzz_target!(|harness: Harness| {
+    let Harness { mut storage, ops } = harness;
+    let mut fsv: FixedSliceVec<String> = FixedSliceVec::from_bytes(&mut storage[..]);
+    for op in ops {
+        match op {
+            VecLikeOp::Clear => {
+                fsv.clear();
+            }
+            VecLikeOp::Pop => {
+                let _ = fsv.pop();
+            }
+            VecLikeOp::Push(s) => {
+                let _ = fsv.try_push(s);
+            }
+            VecLikeOp::Remove(index) => {
+                let _ = fsv.try_remove(index);
+            }
+            VecLikeOp::SwapRemove(index) => {
+                let _ = fsv.try_swap_remove(index);
+            }
+            VecLikeOp::Truncate(len) => {
+                let _ = fsv.truncate(len);
+            }
+            VecLikeOp::Extend(other) => {
+                let _ = fsv.try_extend(other.into_iter());
+            }
+        }
+    }
+});

--- a/src/single.rs
+++ b/src/single.rs
@@ -31,10 +31,10 @@ impl<E> From<SplitUninitError> for EmbedValueError<E> {
 /// Panics in debug mode if destination slice's underlying
 /// pointer has somehow been contrived to be null.
 ///
-/// This function nothing to ensure that the embedded value will be dropped
-/// when the returned reference is dropped. The caller is responsible
-/// for cleaning up any side effects of the embedded value outside of
-/// the destination slice.
+/// This function does nothing to ensure that the embedded value will be
+/// dropped when the returned reference is dropped. The caller is
+/// responsible for cleaning up any side effects of the embedded value
+/// outside of the destination slice.
 #[inline]
 pub fn embed<'a, T, F, E>(destination: &'a mut [u8], f: F) -> Result<&'a mut T, EmbedValueError<E>>
 where
@@ -66,10 +66,10 @@ where
 /// Panics in debug mode if destination slice's underlying
 /// pointer has somehow been contrived to be null.
 ///
-/// This function nothing to ensure that the embedded value will be dropped
-/// when the returned reference is dropped. The caller is responsible
-/// for cleaning up any side effects of the embedded value outside of
-/// the destination slice.
+/// This function does nothing to ensure that the embedded value will be
+/// dropped when the returned reference is dropped. The caller is
+/// responsible for cleaning up any side effects of the embedded value
+/// outside of the destination slice.
 #[inline]
 pub fn embed_uninit<'a, T, F, E>(
     destination: &'a mut [MaybeUninit<u8>],

--- a/src/single.rs
+++ b/src/single.rs
@@ -25,6 +25,16 @@ impl<E> From<SplitUninitError> for EmbedValueError<E> {
 /// The user-provided constructor function also has access to the
 /// portions of the byte slice after the region allocated for
 /// the embedded value itself.
+///
+/// # Safety
+///
+/// Panics in debug mode if destination slice's underlying
+/// pointer has somehow been contrived to be null.
+///
+/// This function nothing to ensure that the embedded value will be dropped
+/// when the returned reference is dropped. The caller is responsible
+/// for cleaning up any side effects of the embedded value outside of
+/// the destination slice.
 #[inline]
 pub fn embed<'a, T, F, E>(destination: &'a mut [u8], f: F) -> Result<&'a mut T, EmbedValueError<E>>
 where
@@ -36,9 +46,11 @@ where
         let ptr = uninit_ref.as_mut_ptr();
         *ptr = f(suffix).map_err(EmbedValueError::ConstructionError)?;
         // We literally just initialized the value, so it's safe to call it init
-        Ok(ptr
-            .as_mut()
-            .expect("Just initialized the value and the pointer is based on a non-null slice"))
+        if let Some(ptr) = ptr.as_mut() {
+            Ok(ptr)
+        } else {
+            unreachable!("Just initialized the value and the pointer is based on a non-null slice")
+        }
     }
 }
 
@@ -48,6 +60,16 @@ where
 /// The user-provided constructor function also has access to the
 /// portions of the byte slice after the region allocated for
 /// the embedded value itself.
+///
+/// # Safety
+///
+/// Panics in debug mode if destination slice's underlying
+/// pointer has somehow been contrived to be null.
+///
+/// This function nothing to ensure that the embedded value will be dropped
+/// when the returned reference is dropped. The caller is responsible
+/// for cleaning up any side effects of the embedded value outside of
+/// the destination slice.
 #[inline]
 pub fn embed_uninit<'a, T, F, E>(
     destination: &'a mut [MaybeUninit<u8>],
@@ -62,9 +84,11 @@ where
         let ptr = uninit_ref.as_mut_ptr();
         *ptr = f(suffix).map_err(EmbedValueError::ConstructionError)?;
         // We literally just initialized the value, so it's safe to call it init
-        Ok(ptr
-            .as_mut()
-            .expect("Just initialized the value and the pointer is based on a non-null slice"))
+        if let Some(ptr) = ptr.as_mut() {
+            Ok(ptr)
+        } else {
+            unreachable!("Just initialized the value and the pointer is based on a non-null slice")
+        }
     }
 }
 
@@ -96,17 +120,13 @@ pub fn split_uninit_from_bytes<T>(
     // as its parameterized type, and our knowledge of the implementation
     // of `split_uninit_from_uninit_bytes`, namely that it never accesses
     // or mutates any content passed to it.
+    let uninit_bytes = unsafe { &mut *(destination as *mut [u8] as *mut [MaybeUninit<u8>]) };
     let (prefix, uninit_ref, suffix): (_, &mut MaybeUninit<T>, _) =
-        split_uninit_from_uninit_bytes(unsafe {
-            &mut *(destination as *mut [u8] as *mut [core::mem::MaybeUninit<u8>])
-        })?;
-    Ok(unsafe {
-        (
-            &mut *(prefix as *mut [core::mem::MaybeUninit<u8>] as *mut [u8]),
-            transmute(uninit_ref),
-            &mut *(suffix as *mut [core::mem::MaybeUninit<u8>] as *mut [u8]),
-        )
-    })
+        split_uninit_from_uninit_bytes(uninit_bytes)?;
+    let uninit_prefix = unsafe { &mut *(prefix as *mut [MaybeUninit<u8>] as *mut [u8]) };
+    let uninit_ref = unsafe { transmute(uninit_ref) };
+    let uninit_suffix = unsafe { &mut *(suffix as *mut [MaybeUninit<u8>] as *mut [u8]) };
+    Ok((uninit_prefix, uninit_ref, uninit_suffix))
 }
 
 /// Split out a mutable reference to an uninitialized struct at an available
@@ -148,15 +168,12 @@ pub fn split_uninit_from_uninit_bytes<T>(
     let (prefix, rest) = destination.split_at_mut(offset);
     let (middle, suffix) = rest.split_at_mut(size_of::<T>());
     let maybe_uninit = middle.as_mut_ptr() as *mut MaybeUninit<T>;
-    Ok((
-        prefix,
-        unsafe {
-            maybe_uninit
-                .as_mut()
-                .expect("Should be non-null since we rely on the input byte slice being non-null.")
-        },
-        suffix,
-    ))
+    let maybe_uninit = if let Some(maybe_uninit) = unsafe { maybe_uninit.as_mut() } {
+        maybe_uninit
+    } else {
+        unreachable!("Should be non-null since we rely on the input byte slice being non-null.")
+    };
+    Ok((prefix, maybe_uninit, suffix))
 }
 
 #[cfg(test)]
@@ -189,7 +206,7 @@ mod tests {
         if let Err(e) = split_uninit_from_bytes::<ZST>(&mut bytes[..]) {
             assert_eq!(SplitUninitError::ZeroSizedTypesUnsupported, e);
         } else {
-            panic!("Expected an err");
+            unreachable!("Expected an err");
         }
         if let Err(e) = embed(&mut bytes[..], |_| -> Result<ZST, ()> { Ok(ZST) }) {
             assert_eq!(
@@ -197,7 +214,7 @@ mod tests {
                 e
             );
         } else {
-            panic!("Expected an err");
+            unreachable!("Expected an err");
         }
 
         let mut uninit_bytes: [MaybeUninit<u8>; 64] =
@@ -205,7 +222,7 @@ mod tests {
         if let Err(e) = split_uninit_from_uninit_bytes::<ZST>(&mut uninit_bytes[..]) {
             assert_eq!(SplitUninitError::ZeroSizedTypesUnsupported, e);
         } else {
-            panic!("Expected an err");
+            unreachable!("Expected an err");
         }
         if let Err(e) = embed_uninit(&mut uninit_bytes[..], |_| -> Result<ZST, ()> { Ok(ZST) }) {
             assert_eq!(
@@ -213,7 +230,7 @@ mod tests {
                 e
             );
         } else {
-            panic!("Expected an err");
+            unreachable!("Expected an err");
         }
     }
 
@@ -223,10 +240,10 @@ mod tests {
         if let Err(e) = split_uninit_from_bytes::<TooBig>(&mut bytes[..]) {
             match e {
                 SplitUninitError::InsufficientSpace | SplitUninitError::Unalignable => (),
-                _ => panic!("Unexpected error kind"),
+                _ => unreachable!("Unexpected error kind"),
             }
         } else {
-            panic!("Expected an err");
+            unreachable!("Expected an err");
         }
     }
 
@@ -237,26 +254,77 @@ mod tests {
         if let Err(e) = split_uninit_from_uninit_bytes::<TooBig>(&mut uninit_bytes[..]) {
             match e {
                 SplitUninitError::InsufficientSpace | SplitUninitError::Unalignable => (),
-                _ => panic!("Unexpected error kind"),
+                _ => unreachable!("Unexpected error kind"),
             }
         } else {
-            panic!("Expected an err");
+            unreachable!("Expected an err");
         }
+    }
+
+    #[test]
+    fn split_uninit_from_bytes_observe_leftovers() {
+        let mut bytes = [0u8; 61];
+        match split_uninit_from_bytes::<[u16; 3]>(&mut bytes[..]) {
+            Ok((prefix, mid, suffix)) => {
+                *mid = MaybeUninit::new([3, 4, 5]);
+                for v in prefix {
+                    assert_eq!(0, *v);
+                }
+                for v in suffix {
+                    assert_eq!(0, *v);
+                }
+            }
+            Err(SplitUninitError::Unalignable) => return (), // Most likely MIRI messing with align-ability
+            Err(e) => unreachable!("Unexpected error: {:?}", e),
+        }
+    }
+
+    #[test]
+    fn split_uninit_from_uninit_bytes_observe_leftovers() {
+        let mut bytes: [MaybeUninit<u8>; 64] = unsafe { MaybeUninit::uninit().assume_init() };
+        match split_uninit_from_uninit_bytes::<[u16; 3]>(&mut bytes[..]) {
+            Ok((prefix, mid, suffix)) => {
+                *mid = MaybeUninit::new([3, 4, 5]);
+                let had_prefix = prefix.len() > 0;
+                let had_suffix = suffix.len() > 0;
+                assert!(had_prefix | had_suffix);
+            }
+            Err(SplitUninitError::Unalignable) => return (), // Most likely MIRI messing with align-ability
+            Err(e) => unreachable!("Unexpected error: {:?}", e),
+        }
+    }
+
+    #[test]
+    fn split_uninit_from_bytes_empty() {
+        let bytes: &mut [u8] = &mut [];
+        assert_eq!(
+            SplitUninitError::InsufficientSpace,
+            split_uninit_from_bytes::<[u16; 3]>(bytes).unwrap_err()
+        );
+    }
+
+    #[test]
+    fn split_uninit_from_uninit_bytes_empty() {
+        let bytes: &mut [MaybeUninit<u8>] = &mut [];
+        assert_eq!(
+            SplitUninitError::InsufficientSpace,
+            split_uninit_from_uninit_bytes::<[u16; 3]>(bytes).unwrap_err()
+        );
     }
 
     #[test]
     fn embed_not_enough_space_detected() {
         let mut bytes = [0u8; 64];
         if let Err(e) = embed(&mut bytes[..], |_| -> Result<Colossal, ()> {
-            Ok(Colossal::default())
+            unreachable!("Don't expect this to execute since we can tell from the types that there is not enough space")
         }) {
             match e {
                 EmbedValueError::SplitUninitError(SplitUninitError::InsufficientSpace)
                 | EmbedValueError::SplitUninitError(SplitUninitError::Unalignable) => (),
-                _ => panic!("Unexpected error kind"),
+                _ => unreachable!("Unexpected error kind"),
             }
         } else {
-            panic!("Expected an err");
+            unreachable!("Expected an err");
         }
     }
 
@@ -265,15 +333,15 @@ mod tests {
         let mut uninit_bytes: [MaybeUninit<u8>; 64] =
             unsafe { MaybeUninit::uninit().assume_init() };
         if let Err(e) = embed_uninit(&mut uninit_bytes[..], |_| -> Result<Colossal, ()> {
-            Ok(Colossal::default())
+            unreachable!("Don't expect this to execute since we can tell from the types that there is not enough space")
         }) {
             match e {
                 EmbedValueError::SplitUninitError(SplitUninitError::InsufficientSpace)
                 | EmbedValueError::SplitUninitError(SplitUninitError::Unalignable) => (),
-                _ => panic!("Unexpected error kind"),
+                _ => unreachable!("Unexpected error kind"),
             }
         } else {
-            panic!("Expected an err");
+            unreachable!("Expected an err");
         }
     }
 
@@ -283,7 +351,7 @@ mod tests {
         let (prefix, _large_ref, suffix) = match split_uninit_from_bytes::<Large>(&mut bytes[..]) {
             Ok(r) => r,
             Err(SplitUninitError::Unalignable) => return (), // Most likely MIRI messing with align-ability
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => unreachable!("Unexpected error: {:?}", e),
         };
         assert_eq!(
             prefix.len() + core::mem::size_of::<Large>() + suffix.len(),
@@ -299,7 +367,7 @@ mod tests {
             match split_uninit_from_uninit_bytes::<Large>(&mut uninit_bytes[..]) {
                 Ok(r) => r,
                 Err(SplitUninitError::Unalignable) => return (), // Most likely MIRI messing with align-ability
-                Err(e) => panic!("Unexpected error: {:?}", e),
+                Err(e) => unreachable!("Unexpected error: {:?}", e),
             };
         assert_eq!(
             prefix.len() + core::mem::size_of::<Large>() + suffix.len(),
@@ -321,7 +389,7 @@ mod tests {
         }) {
             Ok(r) => r,
             Err(EmbedValueError::SplitUninitError(SplitUninitError::Unalignable)) => return (), // Most likely MIRI messing with align-ability
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => unreachable!("Unexpected error: {:?}", e),
         };
 
         assert_eq!(3, large_ref.medium[0]);
@@ -342,7 +410,7 @@ mod tests {
         }) {
             Ok(r) => r,
             Err(EmbedValueError::SplitUninitError(SplitUninitError::Unalignable)) => return (), // Most likely MIRI messing with align-ability
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => unreachable!("Unexpected error: {:?}", e),
         };
         assert_eq!(3, large_ref.medium[0]);
         assert_eq!(1, large_ref.medium[1]);

--- a/tests/std_required_tests.rs
+++ b/tests/std_required_tests.rs
@@ -1,7 +1,8 @@
 //! Tests that require access to the standard library,
 //! e.g. for catching panics
 
-use fixed_slice_vec::FixedSliceVec;
+use fixed_slice_vec::{FixedSliceVec, IndexError, StorageError};
+use proptest::std_facade::HashMap;
 use std::panic::AssertUnwindSafe;
 
 #[test]
@@ -47,4 +48,30 @@ fn manual_try_swap_remove() {
     assert_eq!(&[0u8, 2, 4, 8], fsv.as_slice());
     assert_eq!(Ok(2), fsv.try_swap_remove(1));
     assert_eq!(&[0u8, 8, 4], fsv.as_slice());
+}
+
+#[test]
+fn hashing_successful() {
+    let expected = [0u8, 2, 4, 8];
+    let mut storage = [0u8; 4];
+    let mut fsv = FixedSliceVec::from_bytes(&mut storage[..]);
+    assert!(fsv.try_extend(expected.iter().copied()).is_ok());
+
+    let mut map = HashMap::new();
+    map.insert(fsv, "foo");
+}
+
+#[test]
+fn formatting_successful() {
+    let index_error = format!("{:?}", IndexError);
+    assert!(index_error.len() > 0);
+    let storage_error = format!("{:?}", StorageError("foo"));
+    assert!(storage_error.len() > 0);
+    assert!(!storage_error.contains("foo"));
+
+    let expected = [0u8, 2, 4, 8];
+    let mut storage = [0u8; 4];
+    let mut fsv = FixedSliceVec::from_bytes(&mut storage[..]);
+    assert!(fsv.try_extend(expected.iter().copied()).is_ok());
+    assert_eq!("[0, 2, 4, 8]", format!("{:?}", fsv))
 }


### PR DESCRIPTION
Starting with `miri` in CI and fuzzing on demand.

Adds sufficient tests to get tarpaulin's coverage over 99% on `vec` module, over 90% on single module.

Fixes https://github.com/auxoncorp/fixed-slice-vec/issues/2