### PR TITLE
Minor version bump as we correct embed_uninit constructor signature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed-slice-vec"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "Zachary Pierce <zack@auxon.io>",
     "Jon Lamb <jon@auxon.io>",

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To add `fixed-slice-vec` to your Rust project, add a dependency to it
 in your Cargo.toml file.
 
 ```toml
-fixed-slice-vec = "0.7"
+fixed-slice-vec = "0.7.1"
 ```
 
 ### Usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! in your Cargo.toml file.
 //!
 //! ```toml
-//! fixed-slice-vec = "0.7"
+//! fixed-slice-vec = "0.7.1"
 //! ```
 //!
 //! ## Usage

--- a/src/single.rs
+++ b/src/single.rs
@@ -82,7 +82,7 @@ pub fn embed_uninit<'a, T, F, E>(
     f: F,
 ) -> Result<&'a mut T, EmbedValueError<E>>
 where
-    F: Fn(&'a mut [MaybeUninit<u8>]) -> Result<T, E>,
+    F: FnOnce(&'a mut [MaybeUninit<u8>]) -> Result<T, E>,
 {
     debug_assert!(!destination.as_ptr().is_null());
     let (_prefix, uninit_ref, suffix) = split_uninit_from_uninit_bytes(destination)?;


### PR DESCRIPTION
In hindsight the change made in https://github.com/auxoncorp/fixed-slice-vec/pull/8 should have also occurred for embed_uninit.