### PR TITLE
Correct spurious early drops in `embed` and `embed_uninit`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed-slice-vec"
-version = "0.7.1"
+version = "0.8.0"
 authors = [
     "Zachary Pierce <zack@auxon.io>",
     "Jon Lamb <jon@auxon.io>",

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To add `fixed-slice-vec` to your Rust project, add a dependency to it
 in your Cargo.toml file.
 
 ```toml
-fixed-slice-vec = "0.7.1"
+fixed-slice-vec = "0.8.0"
 ```
 
 ### Usage

--- a/fuzz/fuzz_targets/vec_like_ops.rs
+++ b/fuzz/fuzz_targets/vec_like_ops.rs
@@ -22,7 +22,7 @@ pub enum VecLikeOp<T> {
 
 fuzz_target!(|harness: Harness| {
     let Harness { mut storage, ops } = harness;
-    let mut fsv: FixedSliceVec<String> = FixedSliceVec::from_bytes(&mut storage[..]);
+    let mut fsv: FixedSliceVec<String> = unsafe { FixedSliceVec::from_bytes(&mut storage[..]) };
     for op in ops {
         match op {
             VecLikeOp::Clear => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! in your Cargo.toml file.
 //!
 //! ```toml
-//! fixed-slice-vec = "0.7.1"
+//! fixed-slice-vec = "0.8.0"
 //! ```
 //!
 //! ## Usage

--- a/src/single.rs
+++ b/src/single.rs
@@ -51,7 +51,7 @@ where
     debug_assert!(!destination.as_ptr().is_null());
     let (_prefix, uninit_ref, suffix) = split_uninit_from_bytes(destination)?;
     let ptr = uninit_ref.as_mut_ptr();
-    *ptr = f(suffix).map_err(EmbedValueError::ConstructionError)?;
+    core::ptr::write(ptr, f(suffix).map_err(EmbedValueError::ConstructionError)?);
     // We literally just initialized the value, so it's safe to call it init
     if let Some(ptr) = ptr.as_mut() {
         Ok(ptr)
@@ -88,7 +88,7 @@ where
     let (_prefix, uninit_ref, suffix) = split_uninit_from_uninit_bytes(destination)?;
     unsafe {
         let ptr = uninit_ref.as_mut_ptr();
-        *ptr = f(suffix).map_err(EmbedValueError::ConstructionError)?;
+        core::ptr::write(ptr, f(suffix).map_err(EmbedValueError::ConstructionError)?);
         // We literally just initialized the value, so it's safe to call it init
         if let Some(ptr) = ptr.as_mut() {
             Ok(ptr)
@@ -425,5 +425,41 @@ mod tests {
         assert_eq!(3, large_ref.medium[0]);
         assert_eq!(1, large_ref.medium[1]);
         assert_eq!(4, large_ref.medium[2]);
+    }
+    #[test]
+    fn embed_does_not_run_drops() {
+        let mut storage: [u8; 16] = [0u8; 16];
+        #[derive(Debug)]
+        struct Target(bool);
+        impl Drop for Target {
+            fn drop(&mut self) {
+                self.0 = true;
+            }
+        }
+        let emb = unsafe {
+            embed(&mut storage[..], move |_leftovers| {
+                Result::<Target, ()>::Ok(Target(false))
+            })
+            .unwrap()
+        };
+
+        assert!(!emb.0);
+    }
+    #[test]
+    fn embed_uninit_does_not_run_drops() {
+        let mut storage: [MaybeUninit<u8>; 16] = unsafe { MaybeUninit::uninit().assume_init() };
+        #[derive(Debug)]
+        struct Target(bool);
+        impl Drop for Target {
+            fn drop(&mut self) {
+                self.0 = true;
+            }
+        }
+        let emb = embed_uninit(&mut storage[..], move |_leftovers| {
+            Result::<Target, ()>::Ok(Target(false))
+        })
+        .unwrap();
+
+        assert!(!emb.0);
     }
 }

--- a/tests/std_required_tests.rs
+++ b/tests/std_required_tests.rs
@@ -5,6 +5,8 @@ use fixed_slice_vec::{FixedSliceVec, IndexError, StorageError};
 use proptest::std_facade::HashMap;
 use std::mem::MaybeUninit;
 use std::panic::AssertUnwindSafe;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 fn uninit_storage() -> [MaybeUninit<u8>; 4] {
     unsafe { MaybeUninit::uninit().assume_init() }
@@ -79,4 +81,53 @@ fn formatting_successful() {
     let mut fsv = FixedSliceVec::from_uninit_bytes(&mut storage[..]);
     assert!(fsv.try_extend(expected.iter().copied()).is_ok());
     assert_eq!("[0, 2, 4, 8]", format!("{:?}", fsv))
+}
+
+struct TrueOnDrop(Arc<AtomicBool>);
+impl Drop for TrueOnDrop {
+    fn drop(&mut self) {
+        self.0.as_ref().store(true, Ordering::SeqCst);
+    }
+}
+
+#[test]
+fn embed_does_not_run_drops_atomic() {
+    let flip = Arc::new(AtomicBool::new(false));
+    let flip_clone = flip.clone();
+    let mut storage: [u8; 16] = [0u8; 16];
+    let emb = unsafe {
+        fixed_slice_vec::single::embed(&mut storage[..], move |_leftovers| {
+            Result::<TrueOnDrop, ()>::Ok(TrueOnDrop(flip_clone))
+        })
+        .unwrap()
+    };
+
+    assert!(!flip.load(Ordering::SeqCst));
+    assert!(!emb.0.load(Ordering::SeqCst));
+}
+#[test]
+fn embed_uninit_does_not_run_drops_atomic() {
+    let flip = Arc::new(AtomicBool::new(false));
+    let flip_clone = flip.clone();
+    let mut storage: [MaybeUninit<u8>; 16] = unsafe { MaybeUninit::uninit().assume_init() };
+    let emb = fixed_slice_vec::single::embed_uninit(&mut storage[..], move |_leftovers| {
+        Result::<TrueOnDrop, ()>::Ok(TrueOnDrop(flip_clone))
+    })
+    .unwrap();
+
+    assert!(!flip.load(Ordering::SeqCst));
+    assert!(!emb.0.load(Ordering::SeqCst));
+}
+
+#[test]
+fn fsv_does_not_run_drops_on_push_atomic() {
+    let flip = Arc::new(AtomicBool::new(false));
+    let mut storage: [MaybeUninit<u8>; 16] = unsafe { MaybeUninit::uninit().assume_init() };
+    {
+        let mut fsv: FixedSliceVec<TrueOnDrop> = FixedSliceVec::from_uninit_bytes(&mut storage);
+        let flip_clone = flip.clone();
+        fsv.try_push(TrueOnDrop(flip_clone)).unwrap();
+        assert!(!flip.load(Ordering::SeqCst));
+    }
+    assert!(flip.load(Ordering::SeqCst));
 }

--- a/tests/std_required_tests.rs
+++ b/tests/std_required_tests.rs
@@ -104,6 +104,13 @@ fn embed_does_not_run_drops_atomic() {
 
     assert!(!flip.load(Ordering::SeqCst));
     assert!(!emb.0.load(Ordering::SeqCst));
+
+    // Manually clean up the Arc to avoid alloc-related-leak
+    unsafe {
+        let ptr: *const TrueOnDrop = emb;
+        let extracted = ptr.read();
+        std::mem::drop(extracted);
+    }
 }
 #[test]
 fn embed_uninit_does_not_run_drops_atomic() {
@@ -117,6 +124,13 @@ fn embed_uninit_does_not_run_drops_atomic() {
 
     assert!(!flip.load(Ordering::SeqCst));
     assert!(!emb.0.load(Ordering::SeqCst));
+
+    // Manually clean up the Arc to avoid alloc-related-leak
+    unsafe {
+        let ptr: *const TrueOnDrop = emb;
+        let extracted = ptr.read();
+        std::mem::drop(extracted);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Includes regression tests and a prospective version bump.