### PR TITLE
Safety improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed-slice-vec"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     "Zachary Pierce <zack@auxon.io>",
     "Jon Lamb <jon@auxon.io>",

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To add `fixed-slice-vec` to your Rust project, add a dependency to it
 in your Cargo.toml file.
 
 ```toml
-fixed-slice-vec = "0.8.0"
+fixed-slice-vec = "0.9.0"
 ```
 
 ### Usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! in your Cargo.toml file.
 //!
 //! ```toml
-//! fixed-slice-vec = "0.8.0"
+//! fixed-slice-vec = "0.9.0"
 //! ```
 //!
 //! ## Usage

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -276,13 +276,8 @@ impl<'a, T: Sized> FixedSliceVec<'a, T> {
         if self.len == 0 {
             return None;
         }
-        let upcoming_len = self.len - 1;
-        let v = Some(unsafe {
-            let item_slice = &self.storage[upcoming_len..self.len];
-            (item_slice.as_ptr() as *const T).read()
-        });
-        self.len = upcoming_len;
-        v
+        self.len -= 1;
+        Some(unsafe { self.storage[self.len].as_ptr().read() })
     }
 
     /// Removes the FixedSliceVec's tracking of all items in it while retaining the

--- a/tests/std_required_tests.rs
+++ b/tests/std_required_tests.rs
@@ -146,6 +146,26 @@ fn fsv_does_not_run_drops_on_push_atomic() {
     assert!(flip.load(Ordering::SeqCst));
 }
 
+struct PanicDropHelper {
+    drop_counter: Arc<Mutex<usize>>,
+    panic_on_drop: Arc<Mutex<bool>>,
+}
+impl Drop for PanicDropHelper {
+    fn drop(&mut self) {
+        if let Ok(mut drop_counter) = self.drop_counter.lock() {
+            *drop_counter = drop_counter.saturating_add(1);
+        }
+        let should_panic = if let Ok(panic_on_drop) = self.panic_on_drop.lock() {
+            *panic_on_drop
+        } else {
+            false
+        };
+        if should_panic {
+            panic!("As you wish");
+        }
+    }
+}
+
 #[test]
 fn double_drop_averted_despite_panic_during_clear() {
     // Detect the case when a panic in the middle of a `clear` call
@@ -161,30 +181,11 @@ fn double_drop_averted_despite_panic_during_clear() {
         Arc::new(Mutex::new(true)),
         Arc::new(Mutex::new(false)),
     ];
-    struct Helper {
-        drop_counter: Arc<Mutex<usize>>,
-        panic_on_drop: Arc<Mutex<bool>>,
-    }
-    impl Drop for Helper {
-        fn drop(&mut self) {
-            if let Ok(mut drop_counter) = self.drop_counter.lock() {
-                *drop_counter = drop_counter.saturating_add(1);
-            }
-            let should_panic = if let Ok(panic_on_drop) = self.panic_on_drop.lock() {
-                *panic_on_drop
-            } else {
-                false
-            };
-            if should_panic {
-                panic!("As you wish");
-            }
-        }
-    }
     let mut storage: [MaybeUninit<u8>; 1024] = unsafe { MaybeUninit::uninit().assume_init() };
-    let mut fsv: FixedSliceVec<Helper> = FixedSliceVec::from_uninit_bytes(&mut storage);
+    let mut fsv: FixedSliceVec<PanicDropHelper> = FixedSliceVec::from_uninit_bytes(&mut storage);
     for (drop_counter, panic_on_drop) in drop_counters.iter().zip(panic_on_drop_instructions.iter())
     {
-        fsv.push(Helper {
+        fsv.push(PanicDropHelper {
             drop_counter: drop_counter.clone(),
             panic_on_drop: panic_on_drop.clone(),
         });
@@ -208,4 +209,51 @@ fn double_drop_averted_despite_panic_during_clear() {
     assert!(found_n_drops.iter().sum::<usize>() <= 3);
 
     assert!(fsv.is_empty());
+}
+#[test]
+fn double_drop_averted_despite_panic_during_truncate() {
+    // Detect the case when a panic in the middle of a `truncate` call
+    // may leave the FSV in an uncertain state which may cause double-frees
+    // during subsequent calls to `truncate`
+    let drop_counters = vec![
+        Arc::new(Mutex::new(0)),
+        Arc::new(Mutex::new(0)),
+        Arc::new(Mutex::new(0)),
+    ];
+    let panic_on_drop_instructions = vec![
+        Arc::new(Mutex::new(false)),
+        Arc::new(Mutex::new(true)),
+        Arc::new(Mutex::new(false)),
+    ];
+    let mut storage: [MaybeUninit<u8>; 1024] = unsafe { MaybeUninit::uninit().assume_init() };
+    let mut fsv: FixedSliceVec<PanicDropHelper> = FixedSliceVec::from_uninit_bytes(&mut storage);
+    for (drop_counter, panic_on_drop) in drop_counters.iter().zip(panic_on_drop_instructions.iter())
+    {
+        fsv.push(PanicDropHelper {
+            drop_counter: drop_counter.clone(),
+            panic_on_drop: panic_on_drop.clone(),
+        });
+    }
+    let r = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        fsv.truncate(1);
+    }));
+    assert!(r.is_err());
+
+    let found_n_drops: Vec<usize> = drop_counters.iter().map(|dc| *dc.lock().unwrap()).collect();
+    assert!(found_n_drops.iter().sum::<usize>() <= 2);
+
+    assert_eq!(1, fsv.len());
+
+    for panic_on_drop in panic_on_drop_instructions {
+        let mut pod = panic_on_drop.lock().unwrap();
+        *pod = false;
+    }
+
+    fsv.truncate(1);
+    assert!(found_n_drops.iter().sum::<usize>() <= 2);
+    assert_eq!(1, fsv.len());
+
+    fsv.truncate(0);
+    assert!(fsv.is_empty());
+    assert!(found_n_drops.iter().sum::<usize>() <= 3);
 }

--- a/tests/std_required_tests.rs
+++ b/tests/std_required_tests.rs
@@ -6,7 +6,7 @@ use proptest::std_facade::HashMap;
 use std::mem::MaybeUninit;
 use std::panic::AssertUnwindSafe;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 fn uninit_storage() -> [MaybeUninit<u8>; 4] {
     unsafe { MaybeUninit::uninit().assume_init() }
@@ -144,4 +144,68 @@ fn fsv_does_not_run_drops_on_push_atomic() {
         assert!(!flip.load(Ordering::SeqCst));
     }
     assert!(flip.load(Ordering::SeqCst));
+}
+
+#[test]
+fn double_drop_averted_despite_panic_during_clear() {
+    // Detect the case when a panic in the middle of a `clear` call
+    // may leave the FSV in an uncertain state which may cause double-frees
+    // during subsequent calls to `clear`
+    let drop_counters = vec![
+        Arc::new(Mutex::new(0)),
+        Arc::new(Mutex::new(0)),
+        Arc::new(Mutex::new(0)),
+    ];
+    let panic_on_drop_instructions = vec![
+        Arc::new(Mutex::new(false)),
+        Arc::new(Mutex::new(true)),
+        Arc::new(Mutex::new(false)),
+    ];
+    struct Helper {
+        drop_counter: Arc<Mutex<usize>>,
+        panic_on_drop: Arc<Mutex<bool>>,
+    }
+    impl Drop for Helper {
+        fn drop(&mut self) {
+            if let Ok(mut drop_counter) = self.drop_counter.lock() {
+                *drop_counter = drop_counter.saturating_add(1);
+            }
+            let should_panic = if let Ok(panic_on_drop) = self.panic_on_drop.lock() {
+                *panic_on_drop
+            } else {
+                false
+            };
+            if should_panic {
+                panic!("As you wish");
+            }
+        }
+    }
+    let mut storage: [MaybeUninit<u8>; 1024] = unsafe { MaybeUninit::uninit().assume_init() };
+    let mut fsv: FixedSliceVec<Helper> = FixedSliceVec::from_uninit_bytes(&mut storage);
+    for (drop_counter, panic_on_drop) in drop_counters.iter().zip(panic_on_drop_instructions.iter())
+    {
+        fsv.push(Helper {
+            drop_counter: drop_counter.clone(),
+            panic_on_drop: panic_on_drop.clone(),
+        });
+    }
+    let r = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        fsv.clear();
+    }));
+    assert!(r.is_err());
+
+    let found_n_drops: Vec<usize> = drop_counters.iter().map(|dc| *dc.lock().unwrap()).collect();
+    assert!(found_n_drops.iter().sum::<usize>() <= 3);
+
+    assert!(fsv.is_empty());
+
+    for panic_on_drop in panic_on_drop_instructions {
+        let mut pod = panic_on_drop.lock().unwrap();
+        *pod = false;
+    }
+
+    fsv.clear();
+    assert!(found_n_drops.iter().sum::<usize>() <= 3);
+
+    assert!(fsv.is_empty());
 }


### PR DESCRIPTION
* Avert a double-free risk for `clear` and `truncate` when `panic` is recovered-from.
* Adjust `as_mut_ptr` and `as_ptr` to return `MaybeUninit<T>` pointers.
* Tweak some tests to respect the latest business that miri can detect.

Most of these improvements are based on https://github.com/auxoncorp/fixed-slice-vec/issues/19 , thanks @AngelicosPhosphoros !